### PR TITLE
Add Blazor Server scaffold and EF models

### DIFF
--- a/2iDash.sln
+++ b/2iDash.sln
@@ -1,0 +1,20 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "2iDashApp", "2iDashApp/2iDashApp.csproj", "{6E82C669-A127-4D1D-B94A-90F169B0689C}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{6E82C669-A127-4D1D-B94A-90F169B0689C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{6E82C669-A127-4D1D-B94A-90F169B0689C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{6E82C669-A127-4D1D-B94A-90F169B0689C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{6E82C669-A127-4D1D-B94A-90F169B0689C}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+EndGlobal
+

--- a/2iDashApp/2iDashApp.csproj
+++ b/2iDashApp/2iDashApp.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/2iDashApp/App.razor
+++ b/2iDashApp/App.razor
@@ -1,0 +1,10 @@
+<Router AppAssembly="typeof(Program).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="routeData" DefaultLayout="typeof(MainLayout)" />
+    </Found>
+    <NotFound>
+        <LayoutView Layout="typeof(MainLayout)">
+            <p>Sorry, there's nothing at this address.</p>
+        </LayoutView>
+    </NotFound>
+</Router>

--- a/2iDashApp/Data/ApplicationDbContext.cs
+++ b/2iDashApp/Data/ApplicationDbContext.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using _2iDashApp.Model;
+
+namespace _2iDashApp.Data
+{
+    public class ApplicationDbContext : DbContext
+    {
+        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<Organisation> Organisations => Set<Organisation>();
+        public DbSet<SystemModel> Systems => Set<SystemModel>();
+        public DbSet<Site> Sites => Set<Site>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<Organisation>()
+                .HasMany(o => o.Systems)
+                .WithOne(s => s.Organisation)
+                .HasForeignKey(s => s.OrganisationId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<SystemModel>()
+                .HasMany(s => s.Sites)
+                .WithOne(si => si.SystemModel)
+                .HasForeignKey(si => si.SystemModelId)
+                .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/2iDashApp/Data/ApplicationDbContext.cs
+++ b/2iDashApp/Data/ApplicationDbContext.cs
@@ -29,6 +29,10 @@ namespace _2iDashApp.Data
                 .WithOne(si => si.SystemModel)
                 .HasForeignKey(si => si.SystemModelId)
                 .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<Site>()
+                .Property(s => s.Environment)
+                .HasConversion<string>();
         }
     }
 }

--- a/2iDashApp/Model/Organisation.cs
+++ b/2iDashApp/Model/Organisation.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace _2iDashApp.Model
+{
+    public class Organisation
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public string Name { get; set; } = string.Empty;
+
+        public ICollection<SystemModel> Systems { get; set; } = new List<SystemModel>();
+    }
+}

--- a/2iDashApp/Model/Site.cs
+++ b/2iDashApp/Model/Site.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace _2iDashApp.Model
+{
+    public class Site
+    {
+        public int Id { get; set; }
+
+        [Required]
+        [Url]
+        public string Url { get; set; } = string.Empty;
+
+        [Required]
+        [Url]
+        public string HealthUrl { get; set; } = string.Empty;
+
+        [Required]
+        public string Environment { get; set; } = string.Empty; // e.g., Staging, Production
+
+        public int SystemModelId { get; set; }
+        public SystemModel? SystemModel { get; set; }
+    }
+}

--- a/2iDashApp/Model/Site.cs
+++ b/2iDashApp/Model/Site.cs
@@ -3,6 +3,13 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace _2iDashApp.Model
 {
+    public enum SiteEnvironment
+    {
+        Development,
+        Staging,
+        Production
+    }
+
     public class Site
     {
         public int Id { get; set; }
@@ -16,7 +23,7 @@ namespace _2iDashApp.Model
         public string HealthUrl { get; set; } = string.Empty;
 
         [Required]
-        public string Environment { get; set; } = string.Empty; // e.g., Staging, Production
+        public SiteEnvironment Environment { get; set; }
 
         public int SystemModelId { get; set; }
         public SystemModel? SystemModel { get; set; }

--- a/2iDashApp/Model/SystemModel.cs
+++ b/2iDashApp/Model/SystemModel.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace _2iDashApp.Model
+{
+    [Table("Systems")]
+    public class SystemModel
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public string Name { get; set; } = string.Empty;
+
+        public int OrganisationId { get; set; }
+        public Organisation? Organisation { get; set; }
+
+        public ICollection<Site> Sites { get; set; } = new List<Site>();
+    }
+}

--- a/2iDashApp/Pages/Index.razor
+++ b/2iDashApp/Pages/Index.razor
@@ -1,0 +1,5 @@
+@page "/"
+
+<h1>Hello, world!</h1>
+
+Welcome to your new app.

--- a/2iDashApp/Pages/Shared/_Layout.cshtml
+++ b/2iDashApp/Pages/Shared/_Layout.cshtml
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"] - 2iDashApp</title>
+    <base href="~/" />
+    <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
+    <link href="css/site.css" rel="stylesheet" />
+</head>
+<body>
+    @RenderBody()
+
+    <script src="_framework/blazor.server.js"></script>
+</body>
+</html>

--- a/2iDashApp/Pages/_Host.cshtml
+++ b/2iDashApp/Pages/_Host.cshtml
@@ -1,0 +1,24 @@
+@page "/"
+@namespace _2iDashApp.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@{
+    Layout = null;
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>2iDashApp</title>
+    <base href="~/" />
+    <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />
+    <link href="css/site.css" rel="stylesheet" />
+</head>
+<body>
+    <app>
+        <component type="typeof(App)" render-mode="ServerPrerendered" />
+    </app>
+
+    <script src="_framework/blazor.server.js"></script>
+</body>
+</html>

--- a/2iDashApp/Pages/_ViewImports.cshtml
+++ b/2iDashApp/Pages/_ViewImports.cshtml
@@ -1,0 +1,2 @@
+@using _2iDashApp
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/2iDashApp/Pages/_ViewStart.cshtml
+++ b/2iDashApp/Pages/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "_Layout";
+}

--- a/2iDashApp/Program.cs
+++ b/2iDashApp/Program.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.EntityFrameworkCore;
+using _2iDashApp.Data;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+builder.Services.AddRazorPages();
+builder.Services.AddServerSideBlazor();
+
+builder.Services.AddDbContext<ApplicationDbContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+
+app.UseRouting();
+
+app.MapBlazorHub();
+app.MapFallbackToPage("/_Host");
+
+app.Run();

--- a/2iDashApp/Shared/MainLayout.razor
+++ b/2iDashApp/Shared/MainLayout.razor
@@ -1,0 +1,13 @@
+@inherits LayoutComponentBase
+
+<div class="page">
+    <div class="sidebar">
+        <NavMenu />
+    </div>
+
+    <main>
+        <div class="content px-4">
+            @Body
+        </div>
+    </main>
+</div>

--- a/2iDashApp/Shared/NavMenu.razor
+++ b/2iDashApp/Shared/NavMenu.razor
@@ -1,0 +1,5 @@
+<nav class="navbar navbar-dark bg-dark">
+    <div class="container">
+        <a class="navbar-brand" href="">2iDashApp</a>
+    </div>
+</nav>

--- a/2iDashApp/_Imports.razor
+++ b/2iDashApp/_Imports.razor
@@ -1,0 +1,10 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.JSInterop
+@using _2iDashApp
+@using _2iDashApp.Shared

--- a/2iDashApp/appsettings.json
+++ b/2iDashApp/appsettings.json
@@ -1,0 +1,11 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=2iDashDb;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/2iDashApp/wwwroot/css/site.css
+++ b/2iDashApp/wwwroot/css/site.css
@@ -1,0 +1,3 @@
+body {
+    padding-top: 1rem;
+}


### PR DESCRIPTION
## Summary
- scaffold a basic Blazor Server project
- add `Organisation`, `SystemModel`, and `Site` EF Core models
- create `ApplicationDbContext` using SQL Server
- wire up the DbContext and configuration

## Testing
- `dotnet build 2iDashApp/2iDashApp.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cc312470483219592347181f48377