### PR TITLE
Add basic management UI

### DIFF
--- a/2iDashApp/Pages/Organisations.razor
+++ b/2iDashApp/Pages/Organisations.razor
@@ -1,0 +1,49 @@
+@page "/organisations"
+
+<h3>Create Organisation</h3>
+<div class="card-form">
+    <EditForm Model="@newOrg" OnValidSubmit="@CreateOrganisation">
+        <DataAnnotationsValidator />
+        <ValidationSummary />
+        <div class="mb-3">
+            <label class="form-label">Name</label>
+            <InputText class="form-control" @bind-Value="newOrg.Name" />
+        </div>
+        <button class="btn btn-primary" type="submit">Create</button>
+    </EditForm>
+</div>
+
+<h3 class="mt-4">Existing Organisations</h3>
+@if (organisations.Count == 0)
+{
+    <p>No organisations created.</p>
+}
+else
+{
+    <ul class="list-group">
+        @foreach (var org in organisations)
+        {
+            <li class="list-group-item">@org.Name</li>
+        }
+    </ul>
+}
+
+@code {
+    private Organisation newOrg = new();
+    private List<Organisation> organisations = new();
+
+    [Inject] private ApplicationDbContext Db { get; set; } = default!;
+
+    protected override async Task OnInitializedAsync()
+    {
+        organisations = await Db.Organisations.ToListAsync();
+    }
+
+    private async Task CreateOrganisation()
+    {
+        Db.Organisations.Add(newOrg);
+        await Db.SaveChangesAsync();
+        organisations.Add(newOrg);
+        newOrg = new Organisation();
+    }
+}

--- a/2iDashApp/Pages/Sites.razor
+++ b/2iDashApp/Pages/Sites.razor
@@ -1,0 +1,77 @@
+@page "/sites"
+
+<h3>Create Site</h3>
+<div class="card-form">
+    <EditForm Model="@newSite" OnValidSubmit="@CreateSite">
+        <DataAnnotationsValidator />
+        <ValidationSummary />
+        <div class="mb-3">
+            <label class="form-label">Url</label>
+            <InputText class="form-control" @bind-Value="newSite.Url" />
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Health Url</label>
+            <InputText class="form-control" @bind-Value="newSite.HealthUrl" />
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Environment</label>
+            <InputSelect class="form-select" @bind-Value="newSite.Environment">
+                @foreach (SiteEnvironment env in Enum.GetValues(typeof(SiteEnvironment)))
+                {
+                    <option value="@env">@env</option>
+                }
+            </InputSelect>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">System</label>
+            <InputSelect class="form-select" @bind-Value="newSite.SystemModelId">
+                <option value="">-- Select --</option>
+                @foreach (var sys in systems)
+                {
+                    <option value="@sys.Id">@sys.Name</option>
+                }
+            </InputSelect>
+        </div>
+        <button class="btn btn-primary" type="submit">Create</button>
+    </EditForm>
+</div>
+
+<h3 class="mt-4">Existing Sites</h3>
+@if (sites.Count == 0)
+{
+    <p>No sites created.</p>
+}
+else
+{
+    <ul class="list-group">
+        @foreach (var site in sites)
+        {
+            <li class="list-group-item">
+                <div><strong>@site.Url</strong> (@site.Environment) - @site.SystemModel?.Name</div>
+            </li>
+        }
+    </ul>
+}
+
+@code {
+    private Site newSite = new();
+    private List<Site> sites = new();
+    private List<SystemModel> systems = new();
+
+    [Inject] private ApplicationDbContext Db { get; set; } = default!;
+
+    protected override async Task OnInitializedAsync()
+    {
+        systems = await Db.Systems.ToListAsync();
+        sites = await Db.Sites.Include(s => s.SystemModel).ToListAsync();
+    }
+
+    private async Task CreateSite()
+    {
+        Db.Sites.Add(newSite);
+        await Db.SaveChangesAsync();
+        Db.Entry(newSite).Reference(s => s.SystemModel).Load();
+        sites.Add(newSite);
+        newSite = new Site();
+    }
+}

--- a/2iDashApp/Pages/Systems.razor
+++ b/2iDashApp/Pages/Systems.razor
@@ -1,0 +1,62 @@
+@page "/systems"
+
+<h3>Create System</h3>
+<div class="card-form">
+    <EditForm Model="@newSystem" OnValidSubmit="@CreateSystem">
+        <DataAnnotationsValidator />
+        <ValidationSummary />
+        <div class="mb-3">
+            <label class="form-label">Name</label>
+            <InputText class="form-control" @bind-Value="newSystem.Name" />
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Organisation</label>
+            <InputSelect class="form-select" @bind-Value="newSystem.OrganisationId">
+                <option value="">-- Select --</option>
+                @foreach (var org in organisations)
+                {
+                    <option value="@org.Id">@org.Name</option>
+                }
+            </InputSelect>
+        </div>
+        <button class="btn btn-primary" type="submit">Create</button>
+    </EditForm>
+</div>
+
+<h3 class="mt-4">Existing Systems</h3>
+@if (systems.Count == 0)
+{
+    <p>No systems created.</p>
+}
+else
+{
+    <ul class="list-group">
+        @foreach (var sys in systems)
+        {
+            <li class="list-group-item">@sys.Name - @sys.Organisation?.Name</li>
+        }
+    </ul>
+}
+
+@code {
+    private SystemModel newSystem = new();
+    private List<SystemModel> systems = new();
+    private List<Organisation> organisations = new();
+
+    [Inject] private ApplicationDbContext Db { get; set; } = default!;
+
+    protected override async Task OnInitializedAsync()
+    {
+        organisations = await Db.Organisations.ToListAsync();
+        systems = await Db.Systems.Include(s => s.Organisation).ToListAsync();
+    }
+
+    private async Task CreateSystem()
+    {
+        Db.Systems.Add(newSystem);
+        await Db.SaveChangesAsync();
+        Db.Entry(newSystem).Reference(s => s.Organisation).Load();
+        systems.Add(newSystem);
+        newSystem = new SystemModel();
+    }
+}

--- a/2iDashApp/Shared/MainLayout.razor
+++ b/2iDashApp/Shared/MainLayout.razor
@@ -1,13 +1,8 @@
 @inherits LayoutComponentBase
 
-<div class="page">
-    <div class="sidebar">
-        <NavMenu />
+<NavMenu />
+<div class="container">
+    <div class="content px-4">
+        @Body
     </div>
-
-    <main>
-        <div class="content px-4">
-            @Body
-        </div>
-    </main>
 </div>

--- a/2iDashApp/Shared/NavMenu.razor
+++ b/2iDashApp/Shared/NavMenu.razor
@@ -1,5 +1,19 @@
-<nav class="navbar navbar-dark bg-dark">
-    <div class="container">
+<nav class="navbar navbar-expand navbar-dark bg-primary">
+    <div class="container-fluid">
         <a class="navbar-brand" href="">2iDashApp</a>
+        <ul class="navbar-nav me-auto">
+            <li class="nav-item">
+                <NavLink class="nav-link" href="/">Home</NavLink>
+            </li>
+            <li class="nav-item">
+                <NavLink class="nav-link" href="organisations">Organisations</NavLink>
+            </li>
+            <li class="nav-item">
+                <NavLink class="nav-link" href="systems">Systems</NavLink>
+            </li>
+            <li class="nav-item">
+                <NavLink class="nav-link" href="sites">Sites</NavLink>
+            </li>
+        </ul>
     </div>
 </nav>

--- a/2iDashApp/_Imports.razor
+++ b/2iDashApp/_Imports.razor
@@ -8,3 +8,6 @@
 @using Microsoft.JSInterop
 @using _2iDashApp
 @using _2iDashApp.Shared
+@using _2iDashApp.Model
+@using _2iDashApp.Data
+@using Microsoft.EntityFrameworkCore

--- a/2iDashApp/wwwroot/css/site.css
+++ b/2iDashApp/wwwroot/css/site.css
@@ -1,3 +1,17 @@
 body {
     padding-top: 1rem;
+    background-color: #f0f4f8;
+    color: #333;
+}
+
+.navbar {
+    margin-bottom: 1rem;
+}
+
+.card-form {
+    background-color: #ffffff;
+    padding: 1rem;
+    border-radius: 0.5rem;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    margin-bottom: 1.5rem;
 }


### PR DESCRIPTION
## Summary
- add navigation and layout tweaks
- create pages to manage Organisations, Systems and Sites
- style the app with blue and light gray tones
- expose data and DB context via _Imports

## Testing
- `dotnet build 2iDash.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cc7a36f18832189beafdf5d0326be