### PR TITLE
Improve SiteHealth grid layout and alerts

### DIFF
--- a/2iDashApp/Pages/SiteHealth.razor
+++ b/2iDashApp/Pages/SiteHealth.razor
@@ -8,11 +8,11 @@
 }
 else
 {
-    <div class="row row-cols-1 row-cols-md-2 g-4">
+    <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 g-4">
         @foreach (var status in siteStatuses)
         {
             <div class="col">
-                <div class="card col-4 text-white  @(status.IsHealthy ? "bg-success" : "bg-danger")">
+                <div class="card text-white @(status.IsHealthy ? "bg-success" : "flash-red")">
                     <div class="card-body">
                         <h5 class="card-title">@status.Site.Name</h5>
                         <p class="card-text mb-1">
@@ -67,6 +67,10 @@ else
 
             siteStatuses.Add(status);
         }
+
+        siteStatuses = siteStatuses
+            .OrderBy(s => s.IsHealthy)
+            .ToList();
     }
 
     private class SiteStatus

--- a/2iDashApp/wwwroot/css/site.css
+++ b/2iDashApp/wwwroot/css/site.css
@@ -58,3 +58,13 @@ body {
     color: white;
     margin-top: 2px;
 }
+
+@keyframes flash-red {
+    0% { background-color: #dc3545; }
+    50% { background-color: #ff6b6b; }
+    100% { background-color: #dc3545; }
+}
+
+.flash-red {
+    background-color: #dc3545;
+    animation: flash-red 1s linear infinite;}


### PR DESCRIPTION
## Summary
- arrange site health cards in a responsive grid
- highlight unhealthy sites by flashing red
- sort cards so unhealthy sites appear first

## Testing
- `dotnet build 2iDash.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eb17351bc8321bb074272e81804c1