### PR TITLE
Add minimal API project with health endpoint

### DIFF
--- a/2iDash.sln
+++ b/2iDash.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "2iDashApp", "2iDashApp/2iDashApp.csproj", "{6E82C669-A127-4D1D-B94A-90F169B0689C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DashApi", "DashApi/DashApi.csproj", "{7EC52017-8C1B-4A70-AF29-45EC5FD5C75C}"
+EndProject
 Global
 GlobalSection(SolutionConfigurationPlatforms) = preSolution
 Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ GlobalSection(ProjectConfigurationPlatforms) = postSolution
 {6E82C669-A127-4D1D-B94A-90F169B0689C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 {6E82C669-A127-4D1D-B94A-90F169B0689C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 {6E82C669-A127-4D1D-B94A-90F169B0689C}.Release|Any CPU.Build.0 = Release|Any CPU
+{7EC52017-8C1B-4A70-AF29-45EC5FD5C75C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{7EC52017-8C1B-4A70-AF29-45EC5FD5C75C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{7EC52017-8C1B-4A70-AF29-45EC5FD5C75C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{7EC52017-8C1B-4A70-AF29-45EC5FD5C75C}.Release|Any CPU.Build.0 = Release|Any CPU
 EndGlobalSection
 EndGlobal
 

--- a/2iDash/2iDash.sln
+++ b/2iDash/2iDash.sln
@@ -5,17 +5,23 @@ VisualStudioVersion = 17.13.35931.197 d17.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "2iDashApp", "..\2iDashApp\2iDashApp.csproj", "{CDE7E60D-4B98-8CB6-A1AC-38EC98D682D2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DashApi", "..\DashApi\DashApi.csproj", "{D5561D9F-F3A1-41FA-B12C-4E3310DE4ABD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{CDE7E60D-4B98-8CB6-A1AC-38EC98D682D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{CDE7E60D-4B98-8CB6-A1AC-38EC98D682D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{CDE7E60D-4B98-8CB6-A1AC-38EC98D682D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{CDE7E60D-4B98-8CB6-A1AC-38EC98D682D2}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {CDE7E60D-4B98-8CB6-A1AC-38EC98D682D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {CDE7E60D-4B98-8CB6-A1AC-38EC98D682D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {CDE7E60D-4B98-8CB6-A1AC-38EC98D682D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {CDE7E60D-4B98-8CB6-A1AC-38EC98D682D2}.Release|Any CPU.Build.0 = Release|Any CPU
+                {D5561D9F-F3A1-41FA-B12C-4E3310DE4ABD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {D5561D9F-F3A1-41FA-B12C-4E3310DE4ABD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {D5561D9F-F3A1-41FA-B12C-4E3310DE4ABD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {D5561D9F-F3A1-41FA-B12C-4E3310DE4ABD}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/DashApi/DashApi.csproj
+++ b/DashApi/DashApi.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/DashApi/Program.cs
+++ b/DashApi/Program.cs
@@ -1,0 +1,9 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddHealthChecks();
+
+var app = builder.Build();
+
+app.MapHealthChecks("/health");
+
+app.Run();


### PR DESCRIPTION
## Summary
- add a new **DashApi** project targeting .NET 7
- expose a standardized `/health` endpoint
- reference the new project in both solution files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686eb91caf2c832192e0c9c0df0429c5