### PR TITLE
Enforce authentication across 2iDashApp

### DIFF
--- a/2iDashApp/Pages/_Host.cshtml
+++ b/2iDashApp/Pages/_Host.cshtml
@@ -1,4 +1,5 @@
 @page "/"
+@attribute [Authorize]
 @namespace _2iDashApp.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @{

--- a/2iDashApp/Pages/_ViewImports.cshtml
+++ b/2iDashApp/Pages/_ViewImports.cshtml
@@ -1,2 +1,3 @@
 @using _2iDashApp
+@using Microsoft.AspNetCore.Authorization
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/2iDashApp/Program.cs
+++ b/2iDashApp/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.Google;
 using Microsoft.AspNetCore.Authentication;
 using System.Security.Claims;
+using System;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -20,7 +21,19 @@ builder.Services.AddAuthentication(options =>
     options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
     options.DefaultChallengeScheme = GoogleDefaults.AuthenticationScheme;
 })
-    .AddCookie()
+    .AddCookie(options =>
+    {
+        options.LoginPath = "/login";
+        options.Events.OnValidatePrincipal = async ctx =>
+        {
+            var email = ctx.Principal?.FindFirstValue(ClaimTypes.Email);
+            if (string.IsNullOrEmpty(email) || !email.EndsWith("@2iltd.com", StringComparison.OrdinalIgnoreCase))
+            {
+                ctx.RejectPrincipal();
+                await ctx.HttpContext.SignOutAsync();
+            }
+        };
+    })
     .AddGoogle(options =>
     {
         options.ClientId = builder.Configuration["Authentication:Google:ClientId"] ?? string.Empty;


### PR DESCRIPTION
## Summary
- require authentication for the entire Blazor server app
- sign users out when their cookie email isn't `@2iltd.com`
- set cookie login path so unauthenticated users are redirected to `/login`

## Testing
- `dotnet build 2iDashApp/2iDashApp.csproj -nologo` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686ec9824eb8832180aad69e61984de7