### PR TITLE
Fix remote login correlation failure

### DIFF
--- a/2iDashApp/Program.cs
+++ b/2iDashApp/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.Google;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
 using System.Security.Claims;
 using System;
 using System.Threading.Tasks;
@@ -25,6 +26,8 @@ builder.Services.AddAuthentication(options =>
     .AddCookie(options =>
     {
         options.LoginPath = "/login";
+        options.Cookie.SameSite = SameSiteMode.None;
+        options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
         options.Events.OnValidatePrincipal = async ctx =>
         {
             var email = ctx.Principal?.FindFirstValue(ClaimTypes.Email);
@@ -39,6 +42,8 @@ builder.Services.AddAuthentication(options =>
     {
         options.ClientId = builder.Configuration["Authentication:Google:ClientId"] ?? string.Empty;
         options.ClientSecret = builder.Configuration["Authentication:Google:ClientSecret"] ?? string.Empty;
+        options.CorrelationCookie.SameSite = SameSiteMode.None;
+        options.CorrelationCookie.SecurePolicy = CookieSecurePolicy.Always;
         options.Events.OnCreatingTicket = ctx =>
         {
             var email = ctx.Principal?.FindFirstValue(ClaimTypes.Email);


### PR DESCRIPTION
## Summary
- set SameSite and SecurePolicy for auth cookies

## Testing
- `dotnet build 2iDash.sln -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed6f598dc8321a0397aedd9602b82