### PR TITLE
Fix dev login redirect loop

### DIFF
--- a/2iDashApp/Program.cs
+++ b/2iDashApp/Program.cs
@@ -27,7 +27,9 @@ builder.Services.AddAuthentication(options =>
     {
         options.LoginPath = "/login";
         options.Cookie.SameSite = SameSiteMode.None;
-        options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+        // Allow the cookie to be written over HTTP in development
+        // so the login loop does not occur when HTTPS is unavailable.
+        options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
         options.Events.OnValidatePrincipal = async ctx =>
         {
             var email = ctx.Principal?.FindFirstValue(ClaimTypes.Email);


### PR DESCRIPTION
## Summary
- allow cookies over HTTP to avoid redirect loops when running without HTTPS

## Testing
- `dotnet build 2iDash.sln` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686ed91495e083219deddc407b801568